### PR TITLE
Feature: Add IP information to the Carbon request

### DIFF
--- a/spec/carbon_dispatch/request_spec.cr
+++ b/spec/carbon_dispatch/request_spec.cr
@@ -1,0 +1,178 @@
+require "../spec_helper"
+
+describe CarbonDispatch::Request do
+
+  context "#ip" do
+    it "contains the IP information" do
+      mock_http_request = MockRequest.new
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "1.2.3.4" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("1.2.3.4")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "1.2.3.4,3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("1.2.3.4")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "1.2.3.4, 3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("1.2.3.4")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": ["1.2.3.4", "3.4.5.6"] })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("1.2.3.4")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "fe80::202:b3ff:fe1e:8329" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("fe80::202:b3ff:fe1e:8329")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "2620:0:1c00:0:812c:9583:754b:ca11,fd5b:982e:9130:247f:0000:0000:0000:0000" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("2620:0:1c00:0:812c:9583:754b:ca11")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "2620:0:1c00:0:812c:9583:754b:ca11, fd5b:982e:9130:247f:0000:0000:0000:0000" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("2620:0:1c00:0:812c:9583:754b:ca11")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": ["2620:0:1c00:0:812c:9583:754b:ca11", "fd5b:982e:9130:247f:0000:0000:0000:0000"] })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("2620:0:1c00:0:812c:9583:754b:ca11")
+    end
+
+    it "supports forwarded IP information by proxies" do
+      mock_http_request = MockRequest.new
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "1.2.3.4", "HTTP_X_FORWARDED_FOR": "3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("1.2.3.4")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "1.2.3.4", "HTTP_X_FORWARDED_FOR": "3.4.5.6,7.8.9.0" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("1.2.3.4")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "1.2.3.4", "HTTP_X_FORWARDED_FOR": ["3.4.5.6", "7.8.9.0"] })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("1.2.3.4")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": "3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": "3.4.5.6,7.8.9.0" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("7.8.9.0")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": ["3.4.5.6", "7.8.9.0"] })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("7.8.9.0")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": "fe80::202:b3ff:fe1e:8329" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("fe80::202:b3ff:fe1e:8329")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": "2620:0:1c00:0:812c:9583:754b:ca11,fd5b:982e:9130:247f:0000:0000:0000:0000" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("2620:0:1c00:0:812c:9583:754b:ca11")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": ["2620:0:1c00:0:812c:9583:754b:ca11", "fd5b:982e:9130:247f:0000:0000:0000:0000"] })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("2620:0:1c00:0:812c:9583:754b:ca11")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": "unknown,3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": "other,unknown,3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+    end
+
+    it "ignores trusted IP addresses" do
+      mock_http_request = MockRequest.new
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "127.0.0.1,3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "192.168.0.1, 3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": ["10.0.0.1", "3.4.5.6"] })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": ["10.0.0.1", "10.0.0.1", "3.4.5.6"] })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "::1,2620:0:1c00:0:812c:9583:754b:ca11" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("2620:0:1c00:0:812c:9583:754b:ca11")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "2620:0:1c00:0:812c:9583:754b:ca11,::1" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("2620:0:1c00:0:812c:9583:754b:ca11")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "fd5b:982e:9130:247f:0000:0000:0000:0000,2620:0:1c00:0:812c:9583:754b:ca11" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("2620:0:1c00:0:812c:9583:754b:ca11")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "127.0.0.1", "HTTP_X_FORWARDED_FOR": "3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "127.0.0.1", "HTTP_X_FORWARDED_FOR": "10.0.0.1,3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "unix", "HTTP_X_FORWARDED_FOR": "3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "REMOTE_ADDR": "unix:/tmp/foo", "HTTP_X_FORWARDED_FOR": "3.4.5.6" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("3.4.5.6")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": "unknown,192.168.0.1" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("unknown")
+
+      http_request = mock_http_request.get("/", { "HTTP_X_FORWARDED_FOR": "other,unknown,192.168.0.1" })
+      request = CarbonDispatch::Request.new(http_request)
+      request.ip.should eq("unknown")
+    end
+  end
+
+  context "#trusted_proxy?" do
+    it "ignores local and trusted IP addresses" do
+      mock_http_request = MockRequest.new
+      http_request = mock_http_request.get("/", { "HOST": "host.example.org" })
+      request = CarbonDispatch::Request.new(http_request)
+
+      request.trusted_proxy?("127.0.0.1").should eq(0)
+      request.trusted_proxy?("127.0.0.1").should eq(0)
+      request.trusted_proxy?("10.0.0.1").should eq(0)
+      request.trusted_proxy?("172.16.0.1").should eq(0)
+      request.trusted_proxy?("172.20.0.1").should eq(0)
+      request.trusted_proxy?("172.30.0.1").should eq(0)
+      request.trusted_proxy?("172.31.0.1").should eq(0)
+      request.trusted_proxy?("192.168.0.1").should eq(0)
+      request.trusted_proxy?("::1").should eq(0)
+      request.trusted_proxy?("fd00::").should eq(0)
+      request.trusted_proxy?("localhost").should eq(0)
+      request.trusted_proxy?("unix").should eq(0)
+      request.trusted_proxy?("unix:/tmp/sock").should eq(0)
+
+      request.trusted_proxy?("unix.example.org").should eq(nil)
+      request.trusted_proxy?("example.org\n127.0.0.1").should eq(nil)
+      request.trusted_proxy?("127.0.0.1\nexample.org").should eq(nil)
+      request.trusted_proxy?("11.0.0.1").should eq(nil)
+      request.trusted_proxy?("172.15.0.1").should eq(nil)
+      request.trusted_proxy?("172.32.0.1").should eq(nil)
+      request.trusted_proxy?("2001:470:1f0b:18f8::1").should eq(nil)
+    end
+  end
+
+end
+

--- a/spec/support/mock_request.cr
+++ b/spec/support/mock_request.cr
@@ -1,5 +1,16 @@
-class MockRequest < HTTP::Request
-  def initialize
+class MockRequest
 
+  def initialize
   end
+
+  def get(path : String, headers = Hash.new : Hash(String, String | Array(String)))
+    http_headers = HTTP::Headers.new
+
+    headers.each do |key, value|
+      http_headers.add(key, value)
+    end
+
+    HTTP::Request.new("GET", path, http_headers)
+  end
+
 end

--- a/src/carbon_dispatch/request.cr
+++ b/src/carbon_dispatch/request.cr
@@ -9,6 +9,31 @@ class CarbonDispatch::Request
   end
 
   def ip
-    "127.0.0.1"
+    remote_addrs = split_ip_addresses(headers["REMOTE_ADDR"]?)
+    remote_addrs = reject_trusted_ip_addresses(remote_addrs)
+
+    return remote_addrs.first if !remote_addrs.empty?
+
+    forwarded_ips = split_ip_addresses(headers["HTTP_X_FORWARDED_FOR"]?)
+    forwarded_ips = reject_trusted_ip_addresses(forwarded_ips)
+
+    forwarded_ips.last?
   end
+
+  def trusted_proxy?(ip)
+    ip =~ /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i
+  end
+
+  private def split_ip_addresses(ip_addresses)
+    if ip_addresses
+      ip_addresses.strip.split(/[,\s]+/)
+    else
+      [] of String
+    end
+  end
+
+  private def reject_trusted_ip_addresses(ip_addresses)
+    ip_addresses.reject { |ip| trusted_proxy?(ip) }
+  end
+
 end


### PR DESCRIPTION
The implementation is based on the `Rack::Request`.
