### PR TITLE
Feature: Add basic redirect funtionallity to the Carbon controller

### DIFF
--- a/example/config/routes.cr
+++ b/example/config/routes.cr
@@ -1,4 +1,10 @@
 Carbon.application.routes.draw do
+  # TODO: Use the RedirectionsController, once the segmentation fault is fixed.
+  # get "/redirect_to_new", controller: "redirections", action: "to_new"
+  # get "/redirect_to_google", controller: "redirections", action: "to_google"
+  get "/redirect_to_new", controller: "application", action: "redirect_to_new"
+  get "/redirect_to_google", controller: "application", action: "redirect_to_google"
+
   get "/new", controller: "application", action: "new"
   get "/", controller: "application", action: "index"
 end

--- a/example/src/controllers/application_controller.cr
+++ b/example/src/controllers/application_controller.cr
@@ -15,6 +15,14 @@ class ApplicationController < CarbonController::Base
     render_json cookies.cookies
   end
 
+  def redirect_to_new
+    redirect_to "/new"
+  end
+
+  def redirect_to_google
+    redirect_to "http://www.google.com"
+  end
+
   private def before
     Carbon.logger.debug "Before action"
   end

--- a/example/src/controllers/redirections_controller.cr
+++ b/example/src/controllers/redirections_controller.cr
@@ -1,0 +1,9 @@
+class RedirectionsController < ApplicationController
+  def to_new
+    redirect_to "/new"
+  end
+
+  def to_google
+    redirect_to "http://www.google.com"
+  end
+end

--- a/spec/carbon_controller/redirect_spec.cr
+++ b/spec/carbon_controller/redirect_spec.cr
@@ -1,0 +1,214 @@
+require "../spec_helper"
+
+module CarbonControllerTest
+  class RedirectTestController < CarbonController::Base
+    def redirect_relative_path
+      redirect_to "/foo"
+    end
+
+    def redirect_url
+      redirect_to "http://www.example.com"
+    end
+
+    def redirect_url_with_status_hash
+      redirect_to "http://www.example.com", {status: :permanent_redirect}
+    end
+
+    def redirect_to_url_with_unescaped_query_string
+      redirect_to "http://example.com/query?status=new"
+    end
+
+    def redirect_to_url_with_complex_scheme
+      redirect_to "x-test+scheme.complex:redirect"
+    end
+
+    def redirect_back
+      redirect_to :back
+    end
+
+    def redirect_with_header_break
+      redirect_to "/lol\r\nwat"
+    end
+
+    def redirect_with_null_bytes
+      redirect_to "http://www.example.com\000/lol\r\nwat"
+    end
+
+    def redirect_nil
+      redirect_to nil
+    end
+
+    def redirect_http_params
+      redirect_to HTTP::Params.parse("foo=bar&foo=baz&baz=qux")
+    end
+  end
+end
+
+describe CarbonController::Redirect do
+  context ".redirect_to" do
+    it "redirects to a relative path" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+      controller.redirect_relative_path
+
+      response.status.should eq(302)
+      response.location.should eq("http://test.host/foo")
+      response.body.to_s.should eq("")
+    end
+
+    it "redirects to a relative path with non standard port" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host:8888"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+      controller.redirect_relative_path
+
+      response.status.should eq(302)
+      response.location.should eq("http://test.host:8888/foo")
+      response.body.to_s.should eq("")
+    end
+
+    it "redirects to a URL" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+      controller.redirect_url
+
+      response.status.should eq(302)
+      response.location.should eq("http://www.example.com")
+      response.body.to_s.should eq("")
+    end
+
+    it "redirects to a URL with a custom HTTP status hash" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+      controller.redirect_url_with_status_hash
+
+      response.status.should eq(308)
+      response.location.should eq("http://www.example.com")
+      response.body.to_s.should eq("")
+    end
+
+    it "redirects to a URL with unescaped query params" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+      controller.redirect_to_url_with_unescaped_query_string
+
+      response.status.should eq(302)
+      response.location.should eq("http://example.com/query?status=new")
+      response.body.to_s.should eq("")
+    end
+
+    it "redirects to a complex schema" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+      controller.redirect_to_url_with_complex_scheme
+
+      response.status.should eq(302)
+      response.location.should eq("x-test+scheme.complex:redirect")
+      response.body.to_s.should eq("")
+    end
+
+    it "redirects back based on the 'REFERER' HTTP header" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host", "REFERER": "http://www.example.com/hello_world"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+      controller.redirect_back
+
+      response.status.should eq(302)
+      response.location.should eq("http://www.example.com/hello_world")
+      response.body.to_s.should eq("")
+    end
+
+    it "redirects to a relative path, even when there are header and line breaks in the path" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+      controller.redirect_with_header_break
+
+      response.status.should eq(302)
+      response.location.should eq("http://test.host/lolwat")
+      response.body.to_s.should eq("")
+    end
+
+    it "redirects to a URL, even when there are null bytes in the URL" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+      controller.redirect_with_null_bytes
+
+      response.status.should eq(302)
+      response.location.should eq("http://www.example.com/lolwat")
+      response.body.to_s.should eq("")
+    end
+
+    it "raises RedirectBackError, when redirect back with blank 'REFERER' HTTP header" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host", "REFERER": ""})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+
+      expect_raises CarbonController::RedirectBackError do
+        controller.redirect_back
+      end
+    end
+
+    it "raises RedirectBackError, when redirect back with NO 'REFERER' HTTP header" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+
+      expect_raises CarbonController::RedirectBackError do
+        controller.redirect_back
+      end
+    end
+
+    it "raises CarbonControllerError, when redirect with nil" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+
+      expect_raises CarbonController::CarbonControllerError do
+        controller.redirect_nil
+      end
+    end
+
+    it "raises CarbonControllerError, when redirect with HTTP::Params" do
+      http_request = MockRequest.new.get("/", {"HOST": "test.host"})
+      request = CarbonDispatch::Request.new(http_request)
+      response = CarbonDispatch::Response.new
+
+      controller = CarbonControllerTest::RedirectTestController.new(request, response)
+
+      expect_raises CarbonController::CarbonControllerError do
+        controller.redirect_http_params
+      end
+    end
+  end
+end

--- a/spec/lib/http_util_spec.cr
+++ b/spec/lib/http_util_spec.cr
@@ -1,0 +1,47 @@
+require "../spec_helper"
+
+describe HTTPUtil do
+  context ".status_code" do
+    it "returns the HTTP status code for the given status Symbol or String" do
+      status_code = HTTPUtil.status_code(:ok)
+      status_code.should eq(200)
+
+      status_code = HTTPUtil.status_code("ok")
+      status_code.should eq(200)
+
+      status_code = HTTPUtil.status_code(:unprocessable_entity)
+      status_code.should eq(422)
+
+      status_code = HTTPUtil.status_code("unprocessable_entity")
+      status_code.should eq(422)
+
+      status_code = HTTPUtil.status_code(:non_authoritative_information)
+      status_code.should eq(203)
+
+      status_code = HTTPUtil.status_code("non_authoritative_information")
+      status_code.should eq(203)
+    end
+
+    it "returns the given status as Int32, when the given status is NOT a Symbol or String" do
+      status_code = HTTPUtil.status_code(201)
+      status_code.should eq(201)
+
+      status_code = HTTPUtil.status_code(502.32)
+      status_code.should eq(502)
+    end
+
+    it "returns the HTTP status code 500, when the given status is NOT existing" do
+      status_code = HTTPUtil.status_code(:not_ok)
+      status_code.should eq(500)
+
+      status_code = HTTPUtil.status_code("not_ok")
+      status_code.should eq(500)
+
+      status_code = HTTPUtil.status_code(:coffeepot)
+      status_code.should eq(500)
+
+      status_code = HTTPUtil.status_code("coffeepot")
+      status_code.should eq(500)
+    end
+  end
+end

--- a/src/carbon_controller/base.cr
+++ b/src/carbon_controller/base.cr
@@ -14,6 +14,7 @@ module CarbonController
       end
 
       include CarbonController::Head
+      include CarbonController::Redirect
       include CarbonController::Session
       include CarbonController::Cookies
       include CarbonController::Flash

--- a/src/carbon_controller/metal/exceptions.cr
+++ b/src/carbon_controller/metal/exceptions.cr
@@ -1,0 +1,4 @@
+module CarbonController
+  class CarbonControllerError < Exception
+  end
+end

--- a/src/carbon_controller/metal/redirect.cr
+++ b/src/carbon_controller/metal/redirect.cr
@@ -1,0 +1,57 @@
+module CarbonController
+  class RedirectBackError < Exception
+    DEFAULT_MESSAGE = "No HTTP_REFERER was set in the request to this action, so redirect_to :back could not be called successfully."
+
+    def initialize(message = nil)
+      super(message || DEFAULT_MESSAGE)
+    end
+  end
+
+  module Redirect
+    def redirect_to(options = Hash(Symbol, Symbol | String).new, response_status = Hash(Symbol, Symbol).new : Hash(Symbol, Symbol))
+      raise CarbonControllerError.new("Cannot redirect to nil!") if options.nil?
+      raise CarbonControllerError.new("Cannot redirect to a parameter hash!") if options.is_a?(HTTP::Params)
+
+      response.status = _extract_redirect_to_status(options, response_status)
+      response.location = _compute_redirect_to_location(request, options)
+      response.body = ""
+    end
+
+    private def _compute_redirect_to_location(request, options) # :nodoc:
+      # First case:
+      #
+      # The scheme name consist of a letter followed by any combination of
+      # letters, digits, and the plus ("+"), period ("."), or hyphen ("-")
+      # characters; and is terminated by a colon (":").
+      # See http://tools.ietf.org/html/rfc3986#section-3.1
+      # The protocol relative scheme starts with a double slash "//".
+      case options
+      when /\A([a-z][a-z\d\-+\.]*:|\/\/).*/i
+        options
+      when String
+        request.protocol + request.host_with_port + options
+      when :back
+        referer = request.headers["Referer"]?
+
+        if referer && referer != ""
+          referer
+        else
+          raise RedirectBackError.new
+        end
+      else
+        # TODO: Use this once #url_for is implemented
+        # url_for(options)
+      end.to_s.delete("\0\r\n")
+    end
+
+    private def _extract_redirect_to_status(options, response_status)
+      if options.is_a?(Hash) && options.has_key?(:status)
+        HTTPUtil.status_code(options.delete(:status))
+      elsif response_status.has_key?(:status)
+        HTTPUtil.status_code(response_status[:status])
+      else
+        302
+      end
+    end
+  end
+end

--- a/src/carbon_dispatch/request.cr
+++ b/src/carbon_dispatch/request.cr
@@ -12,12 +12,81 @@ class CarbonDispatch::Request
     @path_params = Hash(String, String?).new
   end
 
-  def host
-    uri.host
+  def ssl?
+    scheme == "https"
   end
 
-  def ssl?
-    uri.scheme == "https"
+  def protocol
+    @protocol ||= ssl? ? "https://" : "http://"
+  end
+
+  def scheme(default = true)
+    if headers["HTTPS"]? == "on"
+      "https"
+    elsif headers["HTTP_X_FORWARDED_SSL"]? == "on"
+      "https"
+    elsif headers["HTTP_X_FORWARDED_SCHEME"]?
+      headers["HTTP_X_FORWARDED_SCHEME"]?
+    elsif headers["HTTP_X_FORWARDED_PROTO"]?
+      forwarded_protocol = headers["HTTP_X_FORWARDED_PROTO"]?
+      forwarded_protocol.to_s.split(",").first
+    else
+      "http" if default
+    end
+  end
+
+  def port
+    port_from_host = raw_host_with_port.to_s.match(/:(\d+)$/) { |md| md[1]? }
+
+    port = begin
+      if scheme(false)
+        standard_port
+      elsif port_from_host
+        port_from_host
+      elsif headers["HTTP_X_FORWARDED_PORT"]?
+        headers["HTTP_X_FORWARDED_PORT"]?
+      elsif headers["SERVER_PORT"]?
+        headers["SERVER_PORT"]?
+      else
+        standard_port
+      end
+    end
+
+    port.to_i if port
+  end
+
+  STANDARD_PORTS_FOR_SCHEME = {"http": 80, "https": 443}
+
+  def standard_port
+    STANDARD_PORTS_FOR_SCHEME[scheme]? || 80
+  end
+
+  def standard_port?
+    STANDARD_PORTS_FOR_SCHEME.values.includes?(port)
+  end
+
+  def host_with_port
+    if standard_port?
+      host
+    else
+      "#{host}:#{port}"
+    end
+  end
+
+  def host
+    raw_host_with_port.sub(/:\d+$/, "")
+  end
+
+  def raw_host_with_port
+    forwarded_host = headers["HTTP_X_FORWARDED_HOST"]?
+
+    if forwarded_host
+      forwarded_host.to_s.split(/,\s?/).last
+    else
+      server_name_or_addr = headers["SERVER_NAME"]? || headers["SERVER_ADDR"]?
+
+      headers["HOST"]? || headers["HTTP_HOST"]? || "#{server_name_or_addr}:#{headers["SERVER_PORT"]?}"
+    end
   end
 
   def params

--- a/src/carbon_dispatch/response.cr
+++ b/src/carbon_dispatch/response.cr
@@ -24,4 +24,14 @@ class CarbonDispatch::Response
   def body=(body : String)
     @body = BodyProxy.new(body)
   end
+
+  def location=(url : String)
+    @location = url
+    @headers["Location"] = url
+  end
+
+  def content_type=(mime : String)
+    @content_type = mime
+    @headers["Content-Type"] = mime
+  end
 end

--- a/src/lib/http_util.cr
+++ b/src/lib/http_util.cr
@@ -1,0 +1,74 @@
+class HTTPUtil
+  HTTP_STATUS_CODES = {
+    100 => "Continue",
+    101 => "Switching Protocols",
+    102 => "Processing",
+    200 => "OK",
+    201 => "Created",
+    202 => "Accepted",
+    203 => "Non-Authoritative Information",
+    204 => "No Content",
+    205 => "Reset Content",
+    206 => "Partial Content",
+    207 => "Multi-Status",
+    208 => "Already Reported",
+    226 => "IM Used",
+    300 => "Multiple Choices",
+    301 => "Moved Permanently",
+    302 => "Found",
+    303 => "See Other",
+    304 => "Not Modified",
+    305 => "Use Proxy",
+    307 => "Temporary Redirect",
+    308 => "Permanent Redirect",
+    400 => "Bad Request",
+    401 => "Unauthorized",
+    402 => "Payment Required",
+    403 => "Forbidden",
+    404 => "Not Found",
+    405 => "Method Not Allowed",
+    406 => "Not Acceptable",
+    407 => "Proxy Authentication Required",
+    408 => "Request Timeout",
+    409 => "Conflict",
+    410 => "Gone",
+    411 => "Length Required",
+    412 => "Precondition Failed",
+    413 => "Payload Too Large",
+    414 => "URI Too Long",
+    415 => "Unsupported Media Type",
+    416 => "Range Not Satisfiable",
+    417 => "Expectation Failed",
+    421 => "Misdirected Request",
+    422 => "Unprocessable Entity",
+    423 => "Locked",
+    424 => "Failed Dependency",
+    426 => "Upgrade Required",
+    428 => "Precondition Required",
+    429 => "Too Many Requests",
+    431 => "Request Header Fields Too Large",
+    500 => "Internal Server Error",
+    501 => "Not Implemented",
+    502 => "Bad Gateway",
+    503 => "Service Unavailable",
+    504 => "Gateway Timeout",
+    505 => "HTTP Version Not Supported",
+    506 => "Variant Also Negotiates",
+    507 => "Insufficient Storage",
+    508 => "Loop Detected",
+    510 => "Not Extended",
+    511 => "Network Authentication Required",
+  }
+
+  STRING_TO_STATUS_CODE = HTTP_STATUS_CODES.each_with_object(Hash(String, Int32).new) do |hash, code, message|
+    hash[message.downcase.gsub(/\s|-|'/, '_').to_s] = code
+  end
+
+  def self.status_code(status)
+    if status.is_a?(Symbol) || status.is_a?(String)
+      STRING_TO_STATUS_CODE[status.to_s]? || 500
+    else
+      status.to_i
+    end
+  end
+end


### PR DESCRIPTION
The implementation is based on `ActionController::Redirecting` in Rails.
